### PR TITLE
Label `ssi` module message type

### DIFF
--- a/src/components/Transactions.vue
+++ b/src/components/Transactions.vue
@@ -51,11 +51,19 @@ export default Vue.extend({
             tevents: {},
             latestBlockHeight: "",
             tempTxType: "",
+            customTypes: {
+                "/hypersignprotocol.hidnode.ssi.MsgCreateDID": "Create DID",
+                "/hypersignprotocol.hidnode.ssi.MsgUpdateDID": "Update DID",
+                "/hypersignprotocol.hidnode.ssi.MsgDeactivateDID": "Deactivate DID",
+                "/hypersignprotocol.hidnode.ssi.MsgCreateSchema": "Create Schema"
+            },
             badges: {
                 staking: "info",
                 bank: "primary",
-                create_did: "dark",
-                update_did: "dark"
+                "/hypersignprotocol.hidnode.ssi.MsgCreateDID": "dark",
+                "/hypersignprotocol.hidnode.ssi.MsgUpdateDID": "dark",
+                "/hypersignprotocol.hidnode.ssi.MsgDeactivateDID": "dark",
+                "/hypersignprotocol.hidnode.ssi.MsgCreateSchema": "dark"
             },
             isLoading: false
         }
@@ -92,9 +100,12 @@ export default Vue.extend({
             const type = atob(moduleEvent.attributes[0].value)
             let html = "";
             if(this.badges[type]){
-                html = `<span class='badge badge-pill badge-${this.badges[type]}'>${type}</span>`
-
-            }else{
+                if (!this.customTypes[type]) {
+                    html = `<span class='badge badge-pill badge-${this.badges[type]}'>${type}</span>`
+                } else {
+                    html = `<span class='badge badge-pill badge-${this.badges[type]}'>${this.customTypes[type]}</span>`
+                } 
+            } else {
                 html = `<span class='badge badge-pill badge-secondary'>${type}</span>`
             }
             return html

--- a/src/views/TransactionDetails.vue
+++ b/src/views/TransactionDetails.vue
@@ -117,11 +117,19 @@ export default {
             blockHeight: "",
             txProof: "",
             transfer: {},
+            customTypes: {
+                "/hypersignprotocol.hidnode.ssi.MsgCreateDID": "Create DID",
+                "/hypersignprotocol.hidnode.ssi.MsgUpdateDID": "Update DID",
+                "/hypersignprotocol.hidnode.ssi.MsgDeactivateDID": "Deactivate DID",
+                "/hypersignprotocol.hidnode.ssi.MsgCreateSchema": "Create Schema"
+            },
             badges: {
                 staking: "info",
                 bank: "primary",
-                create_did: "dark",
-                update_did: "dark"
+                "/hypersignprotocol.hidnode.ssi.MsgCreateDID": "dark",
+                "/hypersignprotocol.hidnode.ssi.MsgUpdateDID": "dark",
+                "/hypersignprotocol.hidnode.ssi.MsgDeactivateDID": "dark",
+                "/hypersignprotocol.hidnode.ssi.MsgCreateSchema": "dark"
             },
             staking: null,
             parsedTxDetails: null,
@@ -167,9 +175,12 @@ export default {
             this.txDetails.tevents.type = type;
             let html = "";
             if(this.badges[type]){
-                html = `<span class='badge badge-pill badge-${this.badges[type]}'>${type}</span>`
-
-            }else{
+                if (!this.customTypes[type]) {
+                    html = `<span class='badge badge-pill badge-${this.badges[type]}'>${type}</span>`
+                } else {
+                    html = `<span class='badge badge-pill badge-${this.badges[type]}'>${this.customTypes[type]}</span>`
+                }
+            } else {
                 html = `<span class='badge badge-pill badge-secondary'>${type}</span>`
             }
             return html

--- a/src/views/TransactionList.vue
+++ b/src/views/TransactionList.vue
@@ -65,11 +65,19 @@ export default {
             transactionList: [],
             latestBlockHeight: "2000",
             isLoading: false,
+            customTypes: {
+                "/hypersignprotocol.hidnode.ssi.MsgCreateDID": "Create DID",
+                "/hypersignprotocol.hidnode.ssi.MsgUpdateDID": "Update DID",
+                "/hypersignprotocol.hidnode.ssi.MsgDeactivateDID": "Deactivate DID",
+                "/hypersignprotocol.hidnode.ssi.MsgCreateSchema": "Create Schema"
+            },
             badges: {
                 staking: "info",
                 bank: "primary",
-                create_did: "dark",
-                update_did: "dark"
+                "/hypersignprotocol.hidnode.ssi.MsgCreateDID": "dark",
+                "/hypersignprotocol.hidnode.ssi.MsgUpdateDID": "dark",
+                "/hypersignprotocol.hidnode.ssi.MsgDeactivateDID": "dark",
+                "/hypersignprotocol.hidnode.ssi.MsgCreateSchema": "dark"
             }
         }
     },    
@@ -122,9 +130,12 @@ export default {
             if(moduleEvent && moduleEvent.attributes){
                     const type = atob(moduleEvent.attributes[0].value)
                     if(this.badges[type]){
-                        html = `<span class='badge badge-pill badge-${this.badges[type]}'>${type}</span>`
-
-                    }else{
+                        if (!this.customTypes[type]) {
+                            html = `<span class='badge badge-pill badge-${this.badges[type]}'>${type}</span>`
+                        } else {
+                            html = `<span class='badge badge-pill badge-${this.badges[type]}'>${this.customTypes[type]}</span>`
+                        }
+                    } else {
                         html = `<span class='badge badge-pill badge-secondary'>${type}</span>`
                     }
             }            


### PR DESCRIPTION
Following TX messages for `ssi` have been labelled:

- `/hypersignprotocol.hidnode.ssi.MsgCreateDID`
- `/hypersignprotocol.hidnode.ssi.MsgUpdateDID`
- `/hypersignprotocol.hidnode.ssi.MsgDeactivateDID`
- `/hypersignprotocol.hidnode.ssi.MsgCreateSchema`

Labels are displayed properly

- Dashboard

![image](https://user-images.githubusercontent.com/32813269/166102285-d27594f8-4fbf-4e76-acd7-e3a52186c91b.png)

**Transaction List**

![image](https://user-images.githubusercontent.com/32813269/166102308-1cfd73e7-cff1-4184-8fef-00f5f3b3584b.png)

**Transaction Details**

![image](https://user-images.githubusercontent.com/32813269/166102331-f35c248a-31ab-49bd-995d-d22a5ff85291.png)

